### PR TITLE
feat(header): 헤더 세팅에서 토글로 헤더 모듈들을 활성, 비활성 가능하게 기능 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
         "next": "15.0.3",
         "react": "19.0.0-rc-66855b96-20241106",
         "react-dom": "19.0.0-rc-66855b96-20241106",
-        "react-icons": "^5.3.0"
+        "react-icons": "^5.3.0",
+        "zustand": "^5.0.1"
       },
       "devDependencies": {
         "@types/node": "^20",
@@ -5731,6 +5732,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.1.tgz",
+      "integrity": "sha512-pRET7Lao2z+n5R/HduXMio35TncTlSW68WsYBq2Lg1ASspsNGjpwLAsij3RpouyV6+kHMwwwzP0bZPD70/Jx/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "next": "15.0.3",
     "react": "19.0.0-rc-66855b96-20241106",
     "react-dom": "19.0.0-rc-66855b96-20241106",
-    "react-icons": "^5.3.0"
+    "react-icons": "^5.3.0",
+    "zustand": "^5.0.1"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -7,6 +7,12 @@
   --foreground: rgb(30 41 59); /* bg-slate-800 */
 }
 
+body {
+  color: var(--foreground);
+  background: var(--background);
+  /* font-family: Arial, Helvetica, sans-serif; */
+}
+
 @media (prefers-color-scheme: dark) {
   :root {
     --background: rgb(30 41 59); /* bg-slate-800 */
@@ -14,15 +20,30 @@
   }
 }
 
-body {
-  color: var(--foreground);
-  background: var(--background);
-  /* font-family: Arial, Helvetica, sans-serif; */
-}
-
 @keyframes dots {
   0%, 20% { content: ''; }
   40% { content: '.'; }
   60% { content: '..'; }
   80%, 100% { content: '...'; }
+}
+
+@keyframes pika {
+  0%, 100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0;
+  }
+}
+
+@layer utilities {
+  /* 스크롤바 완전히 숨기기 */
+  .no-scrollbar::-webkit-scrollbar {
+    display: none;
+  }
+  
+  .no-scrollbar {
+    -ms-overflow-style: none;  /* IE and Edge */
+    scrollbar-width: none;  /* Firefox */
+  }
 }

--- a/src/components/common/Toggle.tsx
+++ b/src/components/common/Toggle.tsx
@@ -1,11 +1,19 @@
 interface Props {
   value: boolean
+  disabled?: boolean
   onClick: () => void
 }
 
-export default function Toggle({value, onClick}: Props) {
+export default function Toggle({value, disabled, onClick}: Props) {
   return (
-    <div onClick={onClick} className={`relative w-16 h-8 rounded-2xl p-[2px] flex ${value ? 'justify-end bg-green-600' : 'justify-start bg-slate-400'} items-center cursor-pointer`}>
+    <div onClick={!disabled ? onClick : undefined}
+      className={`
+        w-14 h-8 rounded-2xl p-[2px] flex 
+        ${value ? 'justify-end bg-green-500' : 'justify-start bg-slate-400'} 
+        ${disabled ? 'opacity-40 cursor-not-allowed' : 'cursor-pointer hover:opacity-90 active:scale-95'} 
+        items-center
+      `}
+    >
       <div className="size-7 bg-white rounded-full"></div>
     </div>
   )

--- a/src/components/common/Toggle.tsx
+++ b/src/components/common/Toggle.tsx
@@ -1,0 +1,12 @@
+interface Props {
+  value: boolean
+  onClick: () => void
+}
+
+export default function Toggle({value, onClick}: Props) {
+  return (
+    <div onClick={onClick} className={`relative w-16 h-8 rounded-2xl p-[2px] flex ${value ? 'justify-end bg-green-600' : 'justify-start bg-slate-400'} items-center cursor-pointer`}>
+      <div className="size-7 bg-white rounded-full"></div>
+    </div>
+  )
+}

--- a/src/components/layout/Header/DateInfo/DateInfo.tsx
+++ b/src/components/layout/Header/DateInfo/DateInfo.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useDateTimeStore } from "@/store/useSettingStore"
 import { useEffect, useState } from "react"
 
 interface IDateInfo {
@@ -8,21 +9,25 @@ interface IDateInfo {
   day: string
   hour: string
   minute: string
+  weekDay: string
 }
 
 export default function DateInfo() {
+  const {dateTimeSetting} = useDateTimeStore()
   const [dateInfo, setDateInfo] = useState<IDateInfo | null>(null)
-
+  
   useEffect(() => {
     const interval = setInterval(() => {
       const date = new Date()
+      const weekDay = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
 
       setDateInfo({
         year: String(date.getFullYear()),
         month: String(date.getMonth() + 1).padStart(2, '0'),
         day: String(date.getDate()).padStart(2, '0'),
         hour: String(date.getHours()).padStart(2, '0'),
-        minute: String(date.getMinutes()).padStart(2, '0')
+        minute: String(date.getMinutes()).padStart(2, '0'),
+        weekDay: weekDay[date.getDay()]
       })
     }, 1000)
 
@@ -31,9 +36,33 @@ export default function DateInfo() {
 
   return (
     <article className="flex items-center text-lg">
-      <p>{dateInfo?.year}.</p>
-      <p className="mr-2">{dateInfo?.month}.{dateInfo?.day}</p>
-      <p>{dateInfo?.hour}:{dateInfo?.minute}</p>
+      {dateInfo && (
+      <>
+        {dateTimeSetting.isDate && (
+          <>
+            <>
+              <p>{dateInfo?.year}</p>
+              <p className="mx-1">.</p>
+            </>
+            <>
+              <p>{dateInfo?.month}</p>
+              <p className="mx-1">.</p>
+              <p>{dateInfo?.day}</p>
+            </>
+          </>
+        )}
+        {dateTimeSetting.isWeekDay && (
+          <p className="ml-2">({dateInfo.weekDay})</p>
+        )}
+        {dateTimeSetting.isTime && (
+          <>
+            <p className="ml-3">{dateInfo?.hour}</p>
+            <p className="mx-1 animate-[pika_1s_steps(1)_infinite]">:</p>
+            <p>{dateInfo?.minute}</p>
+          </>
+        )}
+      </>
+      )}
     </article>
   )
 }

--- a/src/components/layout/Header/Setting/Setting.tsx
+++ b/src/components/layout/Header/Setting/Setting.tsx
@@ -5,8 +5,12 @@ import { useOutSideClick } from "@/hooks/useOutSideClick"
 import { useEffect, useRef, useState } from "react"
 import { IoSettingsSharp } from "react-icons/io5"
 import SettingContentWrapper from "./SettingContentWrapper/SettingContentWrapper"
+import Toggle from "@/components/common/Toggle"
+import { useDateTimeStore, useWeatherStore } from "@/store/useSettingStore"
 
 export default function Setting() {
+  const { dateTimeSetting, updateDateTimeSetting } = useDateTimeStore()
+  const { weatherSetting, updateWeatherSetting } = useWeatherStore()
   const [isSetting, setIsSetting] = useState(false)
   const settingRef = useRef<HTMLDivElement>(null)
   const bgColorPalette = [
@@ -49,7 +53,6 @@ export default function Setting() {
     location.reload()
   }
 
-
   useOutSideClick(settingRef, () => setIsSetting(false))
 
   useEffect(() => {
@@ -60,13 +63,45 @@ export default function Setting() {
 
   return (
     <div className="relative" ref={settingRef}>
-      <IoSettingsSharp className="text-3xl cursor-pointer" onClick={() => setIsSetting((prev) => !prev)} />
+      <IoSettingsSharp className="text-[28px] cursor-pointer" onClick={() => setIsSetting((prev) => !prev)} />
       {isSetting && (
-        <article className="gap-3 absolute p-4 right-0 top-10 flex flex-col max-w-[351px] h-96 shadow-md rounded-3xl backdrop-blur-xl bg-slate-200/40 z-30">
-          <SettingContentWrapper>
+        <article className="gap-3 absolute p-4 right-0 top-10 flex flex-col max-w-[351px] h-96 shadow-md rounded-3xl backdrop-blur-xl bg-slate-200/40 z-30 overflow-auto no-scrollbar">
+          <SettingContentWrapper label="Theme">
             {bgColorPalette.map((color, index) => (
-                <div className={`flex-shrink-0 size-9 rounded-full flex justify-center items-center mr-3 ${color.color === 'default' ? 'bg-slate-300' : color.color}`} key={index} onClick={() => setBgColor(color.color)} />
+                <div className={`flex-shrink-0 size-8 rounded-full flex justify-center items-center mr-3 ${color.color === 'default' ? 'bg-slate-300' : color.color}`} key={index} onClick={() => setBgColor(color.color)} />
               ))}
+          </SettingContentWrapper>
+          <SettingContentWrapper label="Date & Time">
+            <div className="flex flex-col gap-3 w-full">
+              <div className="flex justify-between items-center">
+                <h3>Date</h3>
+                <Toggle disabled={false} value={dateTimeSetting.isDate} onClick={() => updateDateTimeSetting({ isDate: !dateTimeSetting.isDate })} />
+              </div>
+              <div className="flex justify-between items-center">
+                <h3>Week Day</h3>
+                <Toggle disabled={false} value={dateTimeSetting.isWeekDay} onClick={() => updateDateTimeSetting({ isWeekDay: !dateTimeSetting.isWeekDay })} />
+              </div>
+              <div className="flex justify-between items-center">
+                <h3>Time</h3>
+                <Toggle disabled={false} value={dateTimeSetting.isTime} onClick={() => updateDateTimeSetting({ isTime: !dateTimeSetting.isTime })} />
+              </div>
+            </div>
+          </SettingContentWrapper>
+          <SettingContentWrapper label="Weather">
+            <div className="flex flex-col gap-3 w-full">
+              <div className="flex justify-between items-center">
+                <h3>Weather</h3>
+                <Toggle disabled={false} value={weatherSetting.isIcon} onClick={() => updateWeatherSetting({ isIcon: !weatherSetting.isIcon })} />
+              </div>
+              <div className="flex justify-between items-center">
+                <h3>Location</h3>
+                <Toggle disabled={false} value={weatherSetting.isLocation} onClick={() => updateWeatherSetting({ isLocation: !weatherSetting.isLocation })} />
+              </div>
+              <div className="flex justify-between items-center">
+                <h3>Temp</h3>
+                <Toggle disabled={false} value={weatherSetting.isTemp} onClick={() => updateWeatherSetting({ isTemp: !weatherSetting.isTemp })} />
+              </div>
+            </div>
           </SettingContentWrapper>
         </article>
       )}

--- a/src/components/layout/Header/Setting/SettingContentWrapper/SettingContentWrapper.tsx
+++ b/src/components/layout/Header/Setting/SettingContentWrapper/SettingContentWrapper.tsx
@@ -1,7 +1,12 @@
-export default function SettingContentWrapper({children}: {children: React.ReactNode}) {
+interface IProps {
+  children: React.ReactNode
+  label: string
+}
+
+export default function SettingContentWrapper({ children, label }: IProps) {
   return (
     <div className="bg-slate-100/20 rounded-2xl py-3 px-2 text-gray-600">
-      <h2 className="mb-3">Theme</h2>
+      <h2 className="mb-3">{label}</h2>
       <div className="w-full overflow-auto flex">
         {children}
       </div>

--- a/src/components/layout/Header/Setting/SettingContentWrapper/SettingContentWrapper.tsx
+++ b/src/components/layout/Header/Setting/SettingContentWrapper/SettingContentWrapper.tsx
@@ -5,10 +5,12 @@ interface IProps {
 
 export default function SettingContentWrapper({ children, label }: IProps) {
   return (
-    <div className="bg-slate-100/20 rounded-2xl py-3 px-2 text-gray-600">
-      <h2 className="mb-3">{label}</h2>
-      <div className="w-full overflow-auto flex">
-        {children}
+    <div className="text-gray-700">
+      <h2 className="mb-3 px-2">{label}</h2>
+      <div className="bg-slate-100/20 rounded-2xl py-3 px-2">
+        <div className="w-full overflow-auto no-scrollbar flex">
+          {children}
+        </div>
       </div>
     </div>
   )

--- a/src/components/layout/Header/WeatherInfo/WeatherInfo.tsx
+++ b/src/components/layout/Header/WeatherInfo/WeatherInfo.tsx
@@ -1,10 +1,12 @@
 'use client'
 
 import { getWeatherInfo, IWeatherInfo } from "@/api/getWeatherInfo"
+import { useWeatherStore } from "@/store/useSettingStore"
 import Image from "next/image"
 import { useEffect, useState } from "react"
 
 export default function WeatherInfo() {
+  const { weatherSetting } = useWeatherStore()
   const [weatherInfo, setWeatherInfo] = useState<IWeatherInfo | null>(null)
 
   useEffect(() => {
@@ -24,15 +26,21 @@ export default function WeatherInfo() {
   return (
     <article>
       {weatherInfo !== null ? (
-        <div className="flex items-center pr-4 rounded-xl hover:bg-slate-50/20 cursor-pointer">
-          <Image 
-            src={`http://openweathermap.org/img/wn/${weatherInfo.weather[0].icon}@2x.png`}
-            alt={weatherInfo.weather[0].description}
-            width={48}
-            height={48}
-          />
-          <p className="mr-2">{weatherInfo.name}</p>
-          <p>{Math.round(weatherInfo.main.temp)}°C</p>
+        <div className="flex items-center pr-4 rounded-xl text-lg">
+          {weatherSetting.isIcon && (
+            <Image 
+              src={`http://openweathermap.org/img/wn/${weatherInfo.weather[0].icon}@2x.png`}
+              alt={weatherInfo.weather[0].description}
+              width={48}
+              height={48}
+            />
+          )}
+          {weatherSetting.isLocation && (
+            <p className="mr-2">{weatherInfo.name}</p>
+          )}
+          {weatherSetting.isTemp && (
+            <p>{Math.round(weatherInfo.main.temp)}°C</p>
+          )}
         </div>
       ) : (
         <p className="after:content-['.'] after:inline-block after:animate-[dots_1.5s_steps(4,end)_infinite] after:w-5">

--- a/src/store/useSettingStore.ts
+++ b/src/store/useSettingStore.ts
@@ -1,14 +1,47 @@
 import { create } from "zustand"
 
-export const useDateTimeStore = create()((set) => ({
+interface IDateTimeSetting {
+  isDate: boolean
+  isTime: boolean
+  isWeekDay: boolean
+}
+
+interface IDateTimeStore {
+  dateTimeSetting: IDateTimeSetting
+  updateDateTimeSetting: (setting: Partial<IDateTimeSetting>) => void
+}
+
+export const useDateTimeStore = create<IDateTimeStore>()((set) => ({
   dateTimeSetting: {
-    isDateTime: true,
     isDate: true,
     isTime: true,
+    isWeekDay: true,
   },
-  // 개별 설정을 업데이트하는 함수
   updateDateTimeSetting: (setting) =>
     set((state) => ({
       dateTimeSetting: { ...state.dateTimeSetting, ...setting }
+    })),
+}))
+
+interface IWeatherSetting {
+  isIcon: boolean
+  isLocation: boolean
+  isTemp: boolean
+}
+
+interface IWeatherStore {
+  weatherSetting: IWeatherSetting
+  updateWeatherSetting: (setting: Partial<IWeatherSetting>) => void
+}
+
+export const useWeatherStore = create<IWeatherStore>()((set) => ({
+  weatherSetting: {
+    isIcon: true,
+    isLocation: true,
+    isTemp: true,
+  },
+  updateWeatherSetting: (setting) =>
+    set((state) => ({
+      weatherSetting: { ...state.weatherSetting, ...setting }
     })),
 }))

--- a/src/store/useSettingStore.ts
+++ b/src/store/useSettingStore.ts
@@ -1,0 +1,14 @@
+import { create } from "zustand"
+
+export const useDateTimeStore = create()((set) => ({
+  dateTimeSetting: {
+    isDateTime: true,
+    isDate: true,
+    isTime: true,
+  },
+  // 개별 설정을 업데이트하는 함수
+  updateDateTimeSetting: (setting) =>
+    set((state) => ({
+      dateTimeSetting: { ...state.dateTimeSetting, ...setting }
+    })),
+}))


### PR DESCRIPTION
* 토글 컴포넌트 추가
* zustand 설치 - persist는 추후에 적용 할 예정
* 시간 표시에서 ':' 부분은 초마다 깜빡임 효과를 추가
* 헤더의 세팅 옵션에서 헤더 정보들의 노출을 켜고 끌 수 있는 기능 추가

https://github.com/user-attachments/assets/05908d80-4aec-42c9-ac64-6a1dbcfbdaca

